### PR TITLE
Fix site title in head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name=viewport content="width=device-width, initial-scale=1">
   
-  <title>{% if page.title %}{{ page.title }} | {{ site.html }}{% else %}{{ site.html }}{% endif %}</title>
+  <title>{% if page.title %}{{ page.title }} | {{ site.name }}{% else %}{{ site.name }}{% endif %}</title>
   {% if site.author %}
     <meta name="author" content="{{ site.author }}">
   {% endif %}
@@ -18,7 +18,7 @@
   <link href="{{ site.baseurl }}/css/main.css" media="screen, projection" rel="stylesheet" type="text/css">
   <link rel="canonical" href="{{ site.baseurl }}{{ page.url }}">
   <link href="{{ site.baseurl }}/favicon.ico" rel="icon">
-  <link rel="alternate" type="application/atom+xml" title="{{ site.html }}" href="{{ site.baseurl }}/atom.xml"/>
+  <link rel="alternate" type="application/atom+xml" title="{{ site.name }}" href="{{ site.baseurl }}/atom.xml"/>
   
   {% include metadata.html %}
   {% include google_analytics.html %} 


### PR DESCRIPTION
This change came in in a recent PR which breaks the title display such that only the page title was displayed in the browser title.